### PR TITLE
a single instance and header improve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+
+.vs/
+bin/
+temp/
+lib/
+

--- a/src/JsModule/JsModule.cpp
+++ b/src/JsModule/JsModule.cpp
@@ -32,7 +32,7 @@ CJsModule* CJsModule::GetInstance()
 // 	}
 // 
 // 	return s_pJsModule;
-	CJsModule js;
+	static CJsModule js;
 	return &js;
 }
 

--- a/src/plugin/file/Directory.hpp
+++ b/src/plugin/file/Directory.hpp
@@ -8,7 +8,7 @@
 #include <shlwapi.h>
 #include <tchar.h>
 #include <shlobj.h>
-#include "../../../../../vs2013-demos/JsModule/src/plugin/socket/Common/Src/GeneralHelper.h"
+#include "../../plugin/socket/Common/Src/GeneralHelper.h"
 using namespace std;
 
 #pragma comment(lib, "shlwapi.lib")

--- a/src/plugin/json/json.cpp
+++ b/src/plugin/json/json.cpp
@@ -41,6 +41,8 @@ namespace json {
 		bool IsValid()
 		{
 			v8::Handle<v8::Value> v = v8pp::json_parse(m_isolate, m_str);
+			if (v.IsEmpty())
+				return false;
 			bool bObj = v->IsObject();
 // 			if (bObj)
 // 			{


### PR DESCRIPTION
```
CJsModule* CJsModule::GetInstance()
{

	static CJsModule js;
	return &js;
}

```
`CJsModule js; ` this variable should be static ?  because otherwise it will be freed when leave the function? 

and a header file path improve ~