### PR TITLE
fix crash

### DIFF
--- a/src/plugin/json/json.cpp
+++ b/src/plugin/json/json.cpp
@@ -41,6 +41,8 @@ namespace json {
 		bool IsValid()
 		{
 			v8::Handle<v8::Value> v = v8pp::json_parse(m_isolate, m_str);
+			if (v.IsEmpty())
+				return false;			
 			bool bObj = v->IsObject();
 // 			if (bObj)
 // 			{


### PR DESCRIPTION
```
var vRet = curl.post("192.168.35.99", "http://192.168.35.99:3000/queryMsg/query", "_trunc=-1&_limit=10", 0, 1);
//parse
var vRoot = json.parse(vRet);
//IsValid
```
`if(vRoot.IsValid()) `can cause crash when 192.168.35.99 is unreachable.
so we need check v as follows in json.cpp
```
v8::Handle<v8::Value> v = v8pp::json_parse(m_isolate, m_str);
if (v.IsEmpty())
return false;
```